### PR TITLE
Jsl mx98360a

### DIFF
--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -47,6 +47,9 @@ struct ipc_msg;
 #define COMP_TYPE_BUFFER	2
 #define COMP_TYPE_PIPELINE	3
 
+/** \brief Scheduling period for IPC task in microseconds. */
+#define IPC_PERIOD_USEC	100
+
 /* validates internal non tail structures within IPC command structure */
 #define IPC_IS_SIZE_INVALID(object)					\
 	(object).hdr.size == sizeof(object) ? 0 : 1

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -1385,7 +1385,7 @@ out:
 
 void ipc_schedule_process(struct ipc *ipc)
 {
-	schedule_task(&ipc->ipc_task, 0, 100);
+	schedule_task(&ipc->ipc_task, 0, IPC_PERIOD_USEC);
 
 	platform_shared_commit(ipc, sizeof(*ipc));
 }

--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -137,6 +137,7 @@ set(TPLGS
 	"sof-jsl-da7219\;sof-jsl-da7219-mx98360a\;-DPLATFORM=jsl-dedede"
 	"sof-imx8mp-wm8960\;sof-imx8mp-wm8960"
 	"sof-smart-amplifier-nocodec\;sof-smart-amplifier-nocodec"
+	"sof-jsl-rt5682\;sof-jsl-rt5682-rt1015"
 )
 
 add_custom_target(topologies ALL)

--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -137,7 +137,8 @@ set(TPLGS
 	"sof-jsl-da7219\;sof-jsl-da7219-mx98360a\;-DPLATFORM=jsl-dedede"
 	"sof-imx8mp-wm8960\;sof-imx8mp-wm8960"
 	"sof-smart-amplifier-nocodec\;sof-smart-amplifier-nocodec"
-	"sof-jsl-rt5682\;sof-jsl-rt5682-rt1015"
+	"sof-jsl-rt5682\;sof-jsl-rt5682-rt1015\;-DPLATFORM=jsl-rt1015"
+	"sof-jsl-rt5682\;sof-jsl-rt5682-mx98360a\;-DPLATFORM=jsl-dedede"
 )
 
 add_custom_target(topologies ALL)

--- a/tools/topology/platform/intel/jsl-rt1015.m4
+++ b/tools/topology/platform/intel/jsl-rt1015.m4
@@ -1,0 +1,12 @@
+#
+# Jasperlake differentiation for pipelines and components
+#
+
+include(`platform/intel/icl.m4')
+
+define(`SET_SSP_CONFIG',
+				`SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
+						SSP_CLOCK(bclk, 2400000, codec_slave),
+						SSP_CLOCK(fsync, 48000, codec_slave),
+						SSP_TDM(2, 25, 3, 3),
+						SSP_CONFIG_DATA(SSP, 1, 24))')

--- a/tools/topology/sof-jsl-rt5682.m4
+++ b/tools/topology/sof-jsl-rt5682.m4
@@ -16,8 +16,7 @@ include(`common/tlv.m4')
 include(`sof/tokens.m4')
 
 # Include JasperLake DSP configuration
-include(`platform/intel/icl.m4')
-include(`platform/intel/dmic.m4')
+include(`platform/intel/'PLATFORM`.m4')
 
 DEBUG_START
 
@@ -173,13 +172,9 @@ DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
 		SSP_TDM(2, 25, 3, 3),
 		SSP_CONFIG_DATA(SSP, 0, 24)))
 
-# SSP 1 (ID: 6) ALC1015
+# SSP 1 (ID: 6)
 DAI_CONFIG(SSP, 1, 6, SSP1-Codec,
-	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
-		SSP_CLOCK(bclk, 2400000, codec_slave),
-		SSP_CLOCK(fsync, 48000, codec_slave),
-		SSP_TDM(2, 25, 3, 3),
-		SSP_CONFIG_DATA(SSP, 1, 24)))
+	SET_SSP_CONFIG)
 
 # 4 HDMI/DP outputs (ID: 3,4,5)
 DAI_CONFIG(HDA, 0, 3, iDisp1,

--- a/tools/topology/sof-jsl-rt5682.m4
+++ b/tools/topology/sof-jsl-rt5682.m4
@@ -1,0 +1,192 @@
+#
+# Topology for JasperLake with rt5682 codec + DMIC + 3 HDMI + Speaker amp
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`ssp.m4')
+include(`hda.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include JasperLake DSP configuration
+include(`platform/intel/icl.m4')
+include(`platform/intel/dmic.m4')
+
+DEBUG_START
+
+#
+# Define the pipelines
+#
+# PCM0 ----> volume -----> SSP1  (Speaker - ALC1015)
+# PCM1 <---> volume <----> SSP0  (Headset - ALC5682)
+# PCM2 ----> volume -----> iDisp1
+# PCM3 ----> volume -----> iDisp2
+# PCM4 ----> volume -----> iDisp3
+# PCM5 <---- volume <---- DMIC01 (dmic 48k capture)
+# PCM6 <---- kpb <---- DMIC16K (dmic 16k capture)
+
+# Define pipeline id for sof-jsl-rt5682.m4
+# to generate dmic setting with kwd when we have dmic
+# define channel
+define(CHANNELS, `4')
+# define kfbm with volume
+define(KFBM_TYPE, `vol-kfbm')
+# define pcm, pipeline and dai id
+define(DMIC_PCM_48k_ID, `5')
+define(DMIC_PIPELINE_48k_ID, `10')
+define(DMIC_DAI_LINK_48k_ID, `1')
+
+define(DMIC_PCM_16k_ID, `6')
+define(DMIC_PIPELINE_16k_ID, `11')
+define(DMIC_PIPELINE_KWD_ID, `12')
+define(DMIC_DAI_LINK_16k_ID, `2')
+# define pcm, pipeline and dai id
+define(KWD_PIPE_SCH_DEADLINE_US, 20000)
+# include the generic dmic with kwd
+include(`platform/intel/intel-generic-dmic-kwd.m4')
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     frames, deadline, priority, core)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s24le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	2, 1, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s24le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	3, 1, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 2 on PCM 2 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	5, 2, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 3 on PCM 3 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	6, 3, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 4 on PCM 4 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	7, 4, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     frames, deadline, priority, core)
+
+# playback DAI is SSP1 using 2 periods
+# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, SSP, 1, SSP1-Codec,
+	PIPELINE_SOURCE_1, 2, s24le,
+	1000, 0, 0)
+
+# playback DAI is SSP0 using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	2, SSP, 0, SSP0-Codec,
+	PIPELINE_SOURCE_2, 2, s24le,
+	1000, 0, 0)
+
+# capture DAI is SSP0 using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	3, SSP, 0, SSP0-Codec,
+	PIPELINE_SINK_3, 2, s24le,
+	1000, 0, 0)
+
+# playback DAI is iDisp1 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	5, HDA, 0, iDisp1,
+	PIPELINE_SOURCE_5, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# playback DAI is iDisp2 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	6, HDA, 1, iDisp2,
+	PIPELINE_SOURCE_6, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# playback DAI is iDisp3 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	7, HDA, 2, iDisp3,
+	PIPELINE_SOURCE_7, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# PCM Low Latency, id 0
+dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
+PCM_PLAYBACK_ADD(Speakers, 0, PIPELINE_PCM_1)
+PCM_DUPLEX_ADD(Headset, 1, PIPELINE_PCM_2, PIPELINE_PCM_3)
+PCM_PLAYBACK_ADD(HDMI1, 2, PIPELINE_PCM_5)
+PCM_PLAYBACK_ADD(HDMI2, 3, PIPELINE_PCM_6)
+PCM_PLAYBACK_ADD(HDMI3, 4, PIPELINE_PCM_7)
+
+#
+# BE conf2igurations - overrides config in ACPI if present
+# The ID is based on the order defined in sof-rt5682.c machine driver.
+#
+dnl DAI_CONFIG(type, dai_index, link_id, name, ssp_config/dmic_config)
+dnl SSP_CONFIG(format, mclk, bclk, fsync, tdm, ssp_config_data)
+dnl SSP_CLOCK(clock, freq, codec_master, polarity)
+dnl SSP_CONFIG_DATA(type, idx, valid bits, mclk_id)
+
+# SSP 0 (ID: 0) ALC5682
+DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
+	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
+		SSP_CLOCK(bclk, 2400000, codec_slave),
+		SSP_CLOCK(fsync, 48000, codec_slave),
+		SSP_TDM(2, 25, 3, 3),
+		SSP_CONFIG_DATA(SSP, 0, 24)))
+
+# SSP 1 (ID: 6) ALC1015
+DAI_CONFIG(SSP, 1, 6, SSP1-Codec,
+	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
+		SSP_CLOCK(bclk, 2400000, codec_slave),
+		SSP_CLOCK(fsync, 48000, codec_slave),
+		SSP_TDM(2, 25, 3, 3),
+		SSP_CONFIG_DATA(SSP, 1, 24)))
+
+# 4 HDMI/DP outputs (ID: 3,4,5)
+DAI_CONFIG(HDA, 0, 3, iDisp1,
+	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 0, 48000, 2)))
+DAI_CONFIG(HDA, 1, 4, iDisp2,
+	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 1, 48000, 2)))
+DAI_CONFIG(HDA, 2, 5, iDisp3,
+	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 2, 48000, 2)))
+
+DEBUG_END


### PR DESCRIPTION
- Added support for ma98360a codec on existing jsl-rt5682 topology.
- Separated topology build configuration for sof-jsl-rt5682-rt1015 & sof-jsl-rt5682-mx98360a
